### PR TITLE
Added mount option for faster NFS sync

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cartodb.vm.network "private_network", ip: "192.168.20.100"
 
     cartodb.vm.synced_folder ".", "/vagrant", disabled: true
-    cartodb.vm.synced_folder "../cartodb/cartodb", "/opt/cartodb", type: "nfs"
+    cartodb.vm.synced_folder "../cartodb/cartodb", "/opt/cartodb", type: "nfs", mount_options: ['actimeo=1']
     cartodb.vm.synced_folder "../cartodb/windshaft-cartodb", "/opt/windshaft-cartodb", type: "nfs"
     cartodb.vm.synced_folder "../cartodb/cartodb-postgresql", "/opt/cartodb-postgresql", type: "nfs"
     cartodb.vm.synced_folder "../cartodb/cartodb-sql-api", "/opt/cartodb-sql-api", type: "nfs"


### PR DESCRIPTION
This makes changes immediate on grunt watch, which were taking like a few seconds to register on my setup.

Source: http://stackoverflow.com/questions/27035702/grunt-watch-detects-file-changes-only-after-5-seconds-with-vagrant-and-nfs